### PR TITLE
chore: add AAPT2 to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ Thumbs.db
 UserInterfaceState.xcuserstate
 
 src/assets/protocol_modules/
+AAPT2


### PR DESCRIPTION
## Summary
- Add `AAPT2` to `.gitignore` to ignore Android Asset Packaging Tool 2 build artifacts

## Test plan
- [x] Verify AAPT2 files are ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)