### PR TITLE
feat: add Cardano support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=http://localhost:4873

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@airgap/aeternity": "0.13.40",
+    "@apex-fusion/cardano": "0.13.40",
     "@airgap/acurast": "0.13.40",
     "@airgap/angular-core": "0.0.56",
     "@airgap/angular-ngrx": "0.0.56",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { AeternityModule } from '@airgap/aeternity'
+import { CardanoModule } from '@apex-fusion/cardano'
 import {
   APP_PLUGIN,
   createV0TezosShieldedTezProtocol,
@@ -173,6 +174,7 @@ export class AppComponent implements AfterViewInit {
   private async initializeProtocols(): Promise<void> {
     this.moduleService.init([
       new BitcoinModule(),
+      new CardanoModule(),
       new EthereumModule(),
       new TezosModule(),
       new PolkadotModule(),


### PR DESCRIPTION
## Summary
- Add `@apex-fusion/cardano` dependency (v0.13.40)
- Register `CardanoModule` in app initialization
- Add `.npmrc` for package registry configuration

## Purpose
Enables Cardano (ADA) transaction signing in the offline vault, completing the air-gapped Cardano workflow alongside airgap-wallet.

## Dependencies
Requires `@apex-fusion/cardano` package to be published (from airgap-iso-cardano repo).

## Test plan
- [ ] Run `npm install` with local registry / GitHub Packages
- [ ] Build the vault APK
- [ ] Verify Cardano appears in supported protocols
- [ ] Test signing a Cardano transaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)